### PR TITLE
Feat/performance feedback

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -19,8 +19,7 @@ class AuthController extends Controller
             'last_name' => 'required|string|between:2,100',
             'email' => 'required|string|email|max:100|unique:users',
             'password' => 'required|string|min:6',
-            'batch_no' => 'required|integer',
-            'division' => 'required|string',
+            'batch_no' => 'required|integer'
         ]);
     
         if($validator->fails()){

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -81,24 +81,20 @@ class ReportController extends Controller
 {
     $userId = Auth::id();
 
-    // Validasi input untuk tanggal yang akan diisi, default ke hari ini.
     $validatedData = $request->validate([
         'content_text' => 'required|string',
         'content_photo' => 'nullable|image|max:2048',
-        'report_date' => 'nullable|date', // Optional, tanggal untuk laporan
+        'report_date' => 'nullable|date',
     ]);
 
-    // Setel tanggal laporan ke hari ini jika tidak ada yang diberikan.
     $reportDate = $validatedData['report_date'] ?? now()->toDateString();
 
-    // Pastikan tanggal laporan tidak melebihi hari ini
     if (Carbon::parse($reportDate)->isAfter(now())) {
         return response()->json([
             'message' => 'You cannot create a report for a future date.',
         ], 400);
     }
 
-    // Cek apakah laporan harian sudah ada untuk tanggal tersebut.
     $existingReport = DailyReport::where('user_id', $userId)
                                   ->whereDate('created_at', $reportDate)
                                   ->first();
@@ -109,7 +105,6 @@ class ReportController extends Controller
         ], 400);
     }
 
-    // Simpan laporan harian baru
     $dailyReport = new DailyReport([
         'user_id' => $userId,
         'content_text' => $validatedData['content_text'],
@@ -246,7 +241,6 @@ class ReportController extends Controller
        $endDate = clone $startDate;
        $endDate->modify('+6 days');
    
-       // Query to filter reports by user ID, division, and date range
        $reports = DailyReport::where('user_id', $id)
            ->whereHas('user', function ($query) use ($division) {
                $query->where('division_id', $division);

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -229,4 +229,28 @@ class ReportController extends Controller
            ->whereDate('created_at', Carbon::today())
            ->exists();
    }
+
+   public function filterCLevelStaffDailyReports($id, $division, $year, $month, $week)
+   {
+       $startDate = new \DateTime("first day of $year-$month");
+       $startDate->modify('+' . (($week - 1) * 7) . ' days');
+       $endDate = clone $startDate;
+       $endDate->modify('+6 days');
+   
+       // Query to filter reports by user ID, division, and date range
+       $reports = DailyReport::where('user_id', $id)
+           ->whereHas('user', function ($query) use ($division) {
+               $query->where('division_id', $division);
+           })
+           ->whereBetween('created_at', [$startDate, $endDate])
+           ->orderBy('created_at', 'desc')
+           ->get();
+   
+       if ($reports->isEmpty()) {
+           return response()->json(['message' => 'Data not found'], Response::HTTP_NOT_FOUND);
+       }
+   
+       return DailyReportResource::collection($reports);
+   }
+
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -17,7 +17,7 @@ class UserResource extends JsonResource
             'instagram' => $this->instagram,
             'linkedin' => $this->linkedin,
             'batch_no' => $this->batch_no,
-            'division' => $this->division,
+            'division_id' => $this->division_id,
             'supervisor_id' => $this->supervisor_id,
             'vice_supervisor_id' => $this->vice_supervisor_id,
             'CFlag' => $this->CFlag,

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class UserService
+{
+    private const STAFF_ROLE = 'Staff';
+    private const HEAD_ROLE = 'Head';
+    private const CO_HEAD_ROLE = 'Co-Head';
+
+    private const SORT_ORDER_STAFF = 3;
+    private const SORT_ORDER_HEAD = 1;
+    private const SORT_ORDER_CO_HEAD = 2;
+
+    public function sortUsersforClevel($users, $cLevelId)
+    {
+        $staffMap = User::where('StFlag', true)
+            ->select('id', 'supervisor_id', 'vice_supervisor_id')
+            ->get()
+            ->mapWithKeys(function ($user) {
+                return [$user->id => $user];
+            });
+
+        return $users->map(function ($user) use ($cLevelId, $staffMap) {
+            if ($user->supervisor_id == $cLevelId) {
+                if ($staffMap->contains('supervisor_id', $user->id)) {
+                    return $this->formatUser($user, self::HEAD_ROLE, self::SORT_ORDER_HEAD);
+                }
+
+                if ($staffMap->contains('vice_supervisor_id', $user->id)) {
+                    return $this->formatUser($user, self::CO_HEAD_ROLE, self::SORT_ORDER_CO_HEAD);
+                }
+            }
+
+            if ($user->StFlag) {
+                return $this->formatUser($user, self::STAFF_ROLE, self::SORT_ORDER_STAFF);
+            }
+
+            return null;
+        })
+        ->filter()
+        ->sortBy('sort_order')
+        ->values();
+    }
+
+    private function formatUser($user, $role, $sortOrder)
+    {
+        return [
+            'id' => $user->id,
+            'name' => "{$user->first_name} {$user->last_name}",
+            'role' => $role,
+            'sort_order' => $sortOrder,
+            'profile_picture' => $user->profile_picture,
+        ];
+    }
+}

--- a/routes/api/v1/api.php
+++ b/routes/api/v1/api.php
@@ -52,7 +52,7 @@ Route::prefix('v1')->group(function () {
                 Route::get('supervisor-staff/{divisionId}/list', [UserController::class, 'getCLevelStaff']);
                 Route::get('report-status/{divisionId}/check', [ReportController::class, 'getDivisionDailyReports']);
                 Route::get('{id}/daily-reports', [ReportController::class, 'getStaffDailyReports']);
-                Route::get('{id}/daily-reports/{year}/{month}/{week}', [ReportController::class, 'filterStaffDailyReports']);
+                Route::get('{id}/{division}/{year}/{month}/{week}', [ReportController::class, 'filterCLevelStaffDailyReports']);
             });
 
             Route::get('weekly', [ReportController::class, 'getWeeklyReport']);

--- a/routes/api/v1/api.php
+++ b/routes/api/v1/api.php
@@ -50,6 +50,7 @@ Route::prefix('v1')->group(function () {
             // Route c-level in Daily Reports
             Route::group(['prefix' => 'c-level'], function () {
                 Route::get('staff', [UserController::class, 'getCLevelStaff']);
+                Route::get('report-status/{divisionId}/check', [ReportController::class, 'getDivisionDailyReports']);
                 Route::get('{id}/daily-reports', [ReportController::class, 'getStaffDailyReports']);
                 Route::get('{id}/daily-reports/{year}/{month}/{week}', [ReportController::class, 'filterStaffDailyReports']);
             });

--- a/routes/api/v1/api.php
+++ b/routes/api/v1/api.php
@@ -70,5 +70,10 @@ Route::prefix('v1')->group(function () {
                 Route::get('staff/{id}/{year}/{month}', [FeedbackController::class,'getStaffMonthlyFeedback']);
                 Route::post('staff/{id}/{year}/{month}', [FeedbackController::class,'createStaffMonthlyFeedback']);
             });
+
+            Route::group(['prefix' => 'c-level'], function () {
+                Route::get('staff/{id}/{year}/{month}', [FeedbackController::class,'getStaffMonthlyFeedback']);
+                Route::post('staff/{id}/{year}/{month}', [FeedbackController::class,'createStaffMonthlyFeedback']);
+            });
         });
 });

--- a/routes/api/v1/api.php
+++ b/routes/api/v1/api.php
@@ -49,7 +49,7 @@ Route::prefix('v1')->group(function () {
 
             // Route c-level in Daily Reports
             Route::group(['prefix' => 'c-level'], function () {
-                Route::get('staff', [UserController::class, 'getCLevelStaff']);
+                Route::get('supervisor-staff/{divisionId}/list', [UserController::class, 'getCLevelStaff']);
                 Route::get('report-status/{divisionId}/check', [ReportController::class, 'getDivisionDailyReports']);
                 Route::get('{id}/daily-reports', [ReportController::class, 'getStaffDailyReports']);
                 Route::get('{id}/daily-reports/{year}/{month}/{week}', [ReportController::class, 'filterStaffDailyReports']);


### PR DESCRIPTION
---

# Description

This pull request introduces a new set of endpoints that allow users to create performance feedback today and the day before. For c-level already view daily report and create and feedback At this stage, role-based access is indicated by a prefix in the route names, as role-based authentication has not yet been implemented.

## Summary of Changes

-**`getCLevelStaff`** to get Supervisor and staff that related to C-LEVEL
-**`getDivisionDailyReports`** to check if all staff and supervisor already fill the daily report based on division
-**`filterCLevelStaffDailyReports`** get daily report based on division, month, week

## USER ENDPOINT *Fix

### Create Daily Report 

Request :

-   Method : GET
-   Endpoint : `/api/v1/reports/daily`
-   Header :
    -   Auth : Bearer Token
    -  content-type: application/json

```json
{
    "content_text": "string",
    "content_photo": "URL",
    "report_date": "DATE"
}
```
Response :

```json
{
  "data": {
    "user_id": "integer",
    "created_at": "DATE",
    "content_text": "string",
    "content_photo": "URL",
    "last_updated_at": "TIMESTAMP"
  }
}
```

## C-LEVEL ENDPOINT

### Check if Supervisor and Staff Daily Report Filled

Request :

-   Method : GET
-   Endpoint : `/api/v1/reports/c-level/report-status/{divisionId}/check`
-   Header :
    -   Accept: application/json
    -   Auth : Bearer Token
Response :

```json
{
  "division_id": "integer",
  "division_name": "String",
  "report_date": "date",
  "team_members": [
    {
      "name": "String",
      "role": "String",
      "profile_picture": "URL",
      "report_filled_today": "boolean"
    },
```
### C-Level Staff

Request :

-   Method : GET
-   Endpoint : `/api/v1/reports/c-level/supervisor-staff/{divisionId}/list`
-   Header :
    -   Accept: application/json
    -   Auth : Bearer Token
Response :

```json
{
  "division_id": "integer",
  "division_name": "string",
  "team_members": [
    {
      "name": "string",
      "role": "string",
      "profile_picture": "URL"
    },
```

### C-Level staff Daily Report with division

Request :
- Method : GET
- Endpoint : `/api/v1/reports/c-level/{id}/{division}/{year}/{month}/{week}`
-   Header :
    -   Accept: application/json
-   Auth:
    - Bearer Token
Response :

```json
{
  "data": [
    {
      "user_id": "integer",
      "created_at": "timestamp",
      "content_text": "string.",
      "content_photo": "URL",
      "last_updated_at": "timestamp"
    },
```

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)


Fixes #22 