### PR TITLE
feat: add respond role when login

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -72,7 +72,8 @@ class AuthController extends Controller
      *         @OA\JsonContent(
      *             @OA\Property(property="access_token", type="string", example="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."),
      *             @OA\Property(property="token_type", type="string", example="bearer"),
-     *             @OA\Property(property="expires_in", type="integer", example=3600)
+     *             @OA\Property(property="expires_in", type="integer", example=3600),
+     *             @OA\Property(property="role", type="string", example="clevel")
      *         )
      *     ),
      *     @OA\Response(
@@ -187,12 +188,22 @@ class AuthController extends Controller
     {
         /** @var JWTGuard $guard */
         $guard = auth('api');
-
-
+        $user = $guard->user();
+    
+        $role = 'guest'; 
+        if ($user->CFlag) {
+            $role = 'clevel';
+        } elseif ($user->Sflag) {
+            $role = 'supervisor';
+        } elseif ($user->StFlag) {
+            $role = 'staff';
+        }
+    
         return response()->json([
             'access_token' => $token,
             'token_type' => 'bearer',
             'expires_in' => $guard->factory()->getTTL() * 60, // Get token expiration time in seconds
+            'role' => $role,
         ]);
     }
 

--- a/routes/api/v1/api.php
+++ b/routes/api/v1/api.php
@@ -15,9 +15,9 @@ use App\Http\Middleware\AllowCLevel;
 use App\Http\Middleware\AuthCheck;
 
 // Public route
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
+// Route::get('/user', function (Request $request) {
+//     return $request->user();
+// })->middleware('auth:sanctum');
 
 // Version 1 API routes
 Route::prefix('v1')->group(function () {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -52,6 +52,10 @@
                                         "expires_in": {
                                             "type": "integer",
                                             "example": 3600
+                                        },
+                                        "role": {
+                                            "type": "string",
+                                            "example": "clevel"
                                         }
                                     },
                                     "type": "object"


### PR DESCRIPTION
### Description
 Add the role response to the api/v1/auth/login endpoint
```
{
    "access_token": "token",
    "token_type": "bearer",
    "expires_in": 3600,
    "role": "staff"
}
```